### PR TITLE
Remove parameter to avid checking certificate of download. 

### DIFF
--- a/third_party/install.sh
+++ b/third_party/install.sh
@@ -21,7 +21,7 @@ cd ..
 rm -rf $ZMQ_DIR
 
 # Get the C++ Wrapper zmq.hpp
-wget https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq.hpp --no-check-certificate
+wget https://raw.githubusercontent.com/zeromq/cppzmq/master/zmq.hpp
 mv zmq.hpp $THIRD_PARTY_DIR/include
 
 # Get MPICH2


### PR DESCRIPTION
Githubusecontent.com should always have a valid certificate. Fix your client, if it is unable to verify the chain.

Hiding downloads from explicitly untrusted sources in an install script is generally a very bad idea (and bad form).