### PR TITLE
Python Binding

### DIFF
--- a/binding/python/examples/theano/cnn.py
+++ b/binding/python/examples/theano/cnn.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# coding:utf8
+
+"""
+This code is adapted from
+http://blog.csdn.net/shadow_guo/article/details/49055823
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Sander Dieleman
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+"""
+
+import theano
+import theano.tensor as T
+import numpy as np
+import matplotlib.pyplot as plt
+plt.ion()
+
+import load_data
+
+from theano.tensor.nnet.conv import conv2d
+from theano.tensor.signal.downsample import max_pool_2d
+
+
+x_train, t_train, x_test, t_test = load_data.load_cifar10()
+labels_test = np.argmax(t_test, axis=1)
+
+
+# reshape data
+x_train = x_train.reshape((x_train.shape[0], 3, 32, 32))
+x_test = x_test.reshape((x_test.shape[0], 3, 32, 32))
+
+
+# define symbolic Theano variables
+x = T.tensor4()
+t = T.matrix()
+
+
+# define model: neural network
+def floatX(x):
+    return np.asarray(x, dtype=theano.config.floatX)
+
+
+def init_weights(shape, name):
+    return theano.shared(floatX(np.random.randn(*shape) * 0.1), name=name)
+
+
+def momentum(cost, params, learning_rate, momentum):
+    grads = theano.grad(cost, params)
+    updates = []
+
+    for p, g in zip(params, grads):
+        mparam_i = theano.shared(np.zeros(p.get_value().shape, dtype=theano.config.floatX))
+        v = momentum * mparam_i - learning_rate * g
+        updates.append((mparam_i, v))
+        updates.append((p, p + v))
+
+    return updates
+
+
+def model(x, w_c1, b_c1, w_c2, b_c2, w_h3, b_h3, w_o, b_o):
+    c1 = T.maximum(0, conv2d(x, w_c1) + b_c1.dimshuffle('x', 0, 'x', 'x'))
+    p1 = max_pool_2d(c1, (3, 3))
+
+    c2 = T.maximum(0, conv2d(p1, w_c2) + b_c2.dimshuffle('x', 0, 'x', 'x'))
+    p2 = max_pool_2d(c2, (2, 2))
+
+    p2_flat = p2.flatten(2)
+    h3 = T.maximum(0, T.dot(p2_flat, w_h3) + b_h3)
+    p_y_given_x = T.nnet.softmax(T.dot(h3, w_o) + b_o)
+    return p_y_given_x
+
+
+w_c1 = init_weights((4, 3, 3, 3), name="w_c1")
+b_c1 = init_weights((4,), name="b_c1")
+w_c2 = init_weights((8, 4, 3, 3), name="w_c2")
+b_c2 = init_weights((8,), name="b_c2")
+w_h3 = init_weights((8 * 4 * 4, 100), name="w_h3")
+b_h3 = init_weights((100,), name="b_h3")
+w_o = init_weights((100, 10), name="w_o")
+b_o = init_weights((10,), name="w_o")
+
+params = [w_c1, b_c1, w_c2, b_c2, w_h3, b_h3, w_o, b_o]
+
+p_y_given_x = model(x, *params)
+y = T.argmax(p_y_given_x, axis=1)
+
+cost = T.mean(T.nnet.categorical_crossentropy(p_y_given_x, t))
+
+updates = momentum(cost, params, learning_rate=0.01, momentum=0.9)
+
+
+# compile theano functions
+train = theano.function([x, t], cost, updates=updates, allow_input_downcast=True)
+predict = theano.function([x], y, allow_input_downcast=True)
+
+
+# train model
+batch_size = 50
+
+for i in range(50):
+    for start in range(0, len(x_train), batch_size):
+        x_batch = x_train[start:start + batch_size]
+        t_batch = t_train[start:start + batch_size]
+        cost = train(x_batch, t_batch)
+
+    predictions_test = predict(x_test)
+    accuracy = np.mean(predictions_test == labels_test)
+
+    print "epoch %d - accuracy: %.4f" % (i + 1, accuracy)

--- a/binding/python/examples/theano/load_data.py
+++ b/binding/python/examples/theano/load_data.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+# coding:utf8
+
+import cPickle
+import os
+import sys
+CUR_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__)))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, os.path.pardir)))
+CIFAR10_DIR = os.path.abspath(os.path.join(CUR_DIR, os.path.pardir, 'data', 'cifar-10-batches-py'))
+
+
+import numpy as np
+
+
+def load_cifar10(data_dir=CIFAR10_DIR):
+    '''
+    we assume these files are in data_dir:
+    batches.meta  data_batch_1 data_batch_2  data_batch_3  data_batch_4
+    data_batch_5  readme.html test_batch
+
+    You can download the data from
+    https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz
+
+    The RGB values are scaled to [0., 1.].
+    '''
+    x_train_l = []
+    t_train_l = []
+
+    for i in xrange(1, 6):
+        filename = os.path.join(data_dir, "data_batch_%d" % i)
+        with open(filename, "rb") as f:
+            data_obj = cPickle.load(f)
+            x_train_l.append(data_obj["data"])
+            t_train_l.extend(data_obj["labels"])
+    x_train = np.concatenate(x_train_l, axis=0) / 255.
+
+    t_train = np.zeros((x_train.shape[0], 10))
+    for i, cls in enumerate(t_train_l):
+        t_train[i, cls] = 1
+
+    with open(os.path.join(data_dir, "test_batch")) as f:
+        data_obj = cPickle.load(f)
+        x_test = data_obj["data"] / 255.
+        t_test_l = data_obj["labels"]
+
+        t_test = np.zeros((x_test.shape[0], 10))
+        for i, cls in enumerate(t_test_l):
+            t_test[i, cls] = 1
+    return x_train, t_train, x_test, t_test

--- a/binding/python/examples/theano/logistic_regression.py
+++ b/binding/python/examples/theano/logistic_regression.py
@@ -399,9 +399,9 @@ def sgd_optimization_mnist(learning_rate=0.13, n_epochs=1000,
             # A worker will only use batch belonged to itself
             if minibatch_index % total_worker == WORKER_ID:
                 minibatch_avg_cost, t_g_W, t_g_b = train_model(minibatch_index,
-                    W_tbh.get_array(), b_tbh.get_array().reshape((1, b_tbh._size)))
-                W_tbh.add_array(-learning_rate * t_g_W)
-                b_tbh.add_array(-learning_rate * t_g_b)
+                    W_tbh.get(), b_tbh.get().reshape((1, b_tbh._size)))
+                W_tbh.add(-learning_rate * t_g_W)
+                b_tbh.add(-learning_rate * t_g_b)
 
                 # iteration number
 
@@ -409,8 +409,8 @@ def sgd_optimization_mnist(learning_rate=0.13, n_epochs=1000,
         # only master worker will output the model
         if IS_MASTER_WORKER and (iter + 1) % validation_frequency == 0:
             # compute zero-one loss on validation set
-            new_W = W_tbh.get_array()
-            new_b = b_tbh.get_array().reshape((1, b_tbh._size))
+            new_W = W_tbh.get()
+            new_b = b_tbh.get().reshape((1, b_tbh._size))
             validation_losses = [validate_model(i, new_W, new_b)
                                  for i in range(n_valid_batches)]
             validation_loss = numpy.mean(validation_losses)

--- a/binding/python/multiverso/theano_ext/sharedvar.py
+++ b/binding/python/multiverso/theano_ext/sharedvar.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+# coding:utf8
+
+from theano.tensor.basic import TensorType, _tensor_py_operators
+from theano.compile import SharedVariable
+from theano.gof import Variable, utils
+import numpy
+import multiverso as mv
+
+
+class MVSharedVariable(SharedVariable):
+    def __init__(self, name, type, value, strict,
+                 allow_downcast=None, container=None):
+        super(MVSharedVariable, self).__init__(name, type, value, strict,
+             allow_downcast, container)
+        self._mv_array = mv.ArrayTableHandler(self.get_value().size)
+
+        self._mv_array.add(self.get_value().reshape((-1,)))
+
+        # I restore a copy of value. It will be used for calculate the update
+        # for multiverso when calling mv_sync
+        self._last_mv_data = self.get_value(borrow=False)
+
+    def mv_sync(self):
+        '''
+        This will add the delta of SharedVariable to parameter server and then
+        get the latest value in multiverso
+        '''
+        # because multiverso always use add method to sync value, the delta
+        # will be the difference of the current value of last synced value
+        self._mv_array.add(self.get_value() - self._last_mv_data)
+
+        self.set_value(self._mv_array.get().reshape(self.get_value().shape))
+        self._last_mv_data = self.get_value(borrow=False)
+
+
+class MVTensorSharedVariable(_tensor_py_operators, MVSharedVariable):
+    pass
+
+
+def mv_shared(value, name=None, strict=False, allow_downcast=None, **kwargs):
+    """Return a MVSharedVariable Variable, initialized with a copy or
+    reference of `value`.
+
+    This function iterates over constructor functions to find a
+    suitable MVSharedVariable subclass.  The suitable one is the first
+    constructor that accept the given value.  See the documentation of
+    :func:`shared_constructor` for the definition of a contructor
+    function.
+
+    This function is meant as a convenient default.  If you want to use a
+    specific shared variable constructor, consider calling it directly.
+
+    .. attribute:: constructors
+
+    A list of shared variable constructors that will be tried in reverse
+    order.
+
+    Notes
+    -----
+    By passing kwargs, you effectively limit the set of potential constructors
+    to those that can accept those kwargs.
+
+    Some shared variable have ``borrow`` as extra kwargs.
+    `See <http://deeplearning.net/software/theano/tutorial/aliasing.\
+    html#borrowing-when-creating-shared-variables>`_ for details.
+
+    Some shared variable have ``broadcastable`` as extra kwargs. As shared
+    variable shapes can change, all dimensions default to not being
+    broadcastable, even if ``value`` has a shape of 1 along some dimension.
+    This parameter allows you to create for example a `row` or `column` 2d
+    tensor.
+
+    """
+
+    try:
+        if isinstance(value, Variable):
+            raise TypeError("Shared variable constructor needs numeric "
+                            "values and not symbolic variables.")
+
+        for ctor in reversed(mv_shared.constructors):
+            try:
+                var = ctor(value, name=name, strict=strict,
+                           allow_downcast=allow_downcast, **kwargs)
+                utils.add_tag_trace(var)
+                return var
+            except TypeError:
+                continue
+            # This may happen when kwargs were supplied
+            # if kwargs were given, the generic_constructor won't be callable.
+            #
+            # This was done on purpose, the rationale being that if kwargs
+            # were supplied, the user didn't want them to be ignored.
+
+    except MemoryError as e:
+        e.args = e.args + ('you might consider'
+                           ' using \'theano.mv_shared(..., borrow=True)\'',)
+        raise
+
+    raise TypeError('No suitable SharedVariable constructor could be found.'
+                    ' Are you sure all kwargs are supported?'
+                    ' We do not support the parameter dtype or type.'
+                    ' value="%s". parameters="%s"' %
+                    (value, kwargs))
+
+mv_shared.constructors = []
+
+
+def shared_constructor(ctor, remove=False):
+    if remove:
+        mv_shared.constructors.remove(ctor)
+    else:
+        mv_shared.constructors.append(ctor)
+    return ctor
+
+
+@shared_constructor
+def mv_tensor_constructor(value, name=None, strict=False, allow_downcast=None,
+                       borrow=False, broadcastable=None, target='cpu'):
+    """
+    MVSharedVariable Constructor for TensorType.
+
+    Notes
+    -----
+    Regarding the inference of the broadcastable pattern...
+    The default is to assume that the value might be resized in any
+    dimension, so the default broadcastable is ``(False,)*len(value.shape)``.
+    The optional `broadcastable` argument will override this default.
+
+    """
+    if target != 'cpu':
+        raise TypeError('not for cpu')
+
+    if not isinstance(value, numpy.ndarray):
+        raise TypeError()
+
+    # if no broadcastable is given, then the default is to assume that
+    # the value might be resized in any dimension in the future.
+    #
+    if broadcastable is None:
+        broadcastable = (False,) * len(value.shape)
+    type = TensorType(value.dtype, broadcastable=broadcastable)
+    return MVTensorSharedVariable(type=type,
+                                value=numpy.array(value, copy=(not borrow)),
+                                name=name,
+                                strict=strict,
+                                allow_downcast=allow_downcast)
+
+
+# TODO implement the following constructor and related SharedVariable
+# <function theano.compile.sharedvalue.generic_constructor>
+# <function theano.tensor.sharedvar.scalar_constructor>
+# <function theano.tensor.shared_randomstreams.randomstate_constructor>


### PR DESCRIPTION

* Add a cnn cifar10  example that uses `multiverso` and `shared variable` . This example doesn't support mpi  multi-process so far. The multi-process version will be committed about tomorrow.
* extend the `SharedVariable` to `MVSharedVariable` in theano.  Theano examples that relies on `SharedVariable` need just a little modification now.    More type of `MVSharedVariable` will be supported latter.