### PR TITLE
Add unified matrix table add interface.

### DIFF
--- a/include/multiverso/table/matrix_table.h
+++ b/include/multiverso/table/matrix_table.h
@@ -36,8 +36,8 @@ public:
            const std::vector<T*>& data_vec, size_t size, 
            const AddOption* option = nullptr);
 
-  void Add(T* data, size_t size, integer_t* row_ids = nullptr,
-           integer_t row_ids_size = 0, const AddOption* option = nullptr);
+  void Add(T* data, size_t size, const AddOption* option = nullptr,
+           integer_t* row_ids = nullptr, integer_t row_ids_size = 0);
 
   int Partition(const std::vector<Blob>& kv,
     std::unordered_map<int, std::vector<Blob>>* out) override;

--- a/include/multiverso/table/matrix_table.h
+++ b/include/multiverso/table/matrix_table.h
@@ -29,15 +29,15 @@ public:
   void Get(const std::vector<integer_t>& row_ids,
            const std::vector<T*>& data_vec, size_t size);
 
-  // Add whole table
-  void Add(T* data, size_t size, const AddOption* option = nullptr);
-
   void Add(integer_t row_id, T* data, size_t size, 
            const AddOption* option = nullptr);
 
   void Add(const std::vector<integer_t>& row_ids,
            const std::vector<T*>& data_vec, size_t size, 
            const AddOption* option = nullptr);
+
+  void Add(T* data, size_t size, integer_t* row_ids = nullptr,
+           integer_t row_ids_size = 0, const AddOption* option = nullptr);
 
   int Partition(const std::vector<Blob>& kv,
     std::unordered_map<int, std::vector<Blob>>* out) override;

--- a/src/table/matrix_table.cpp
+++ b/src/table/matrix_table.cpp
@@ -90,13 +90,6 @@ void MatrixWorkerTable<T>::Get(const std::vector<integer_t>& row_ids,
 }
 
 template <typename T>
-void MatrixWorkerTable<T>::Add(T* data, size_t size, const AddOption* option) {
-  CHECK(size == num_col_ * num_row_);
-  integer_t whole_table = -1;
-  Add(whole_table, data, size, option);
-}
-
-template <typename T>
 void MatrixWorkerTable<T>::Add(integer_t row_id, T* data, size_t size, 
                                const AddOption* option) {
   if (row_id >= 0) CHECK(size == num_col_);
@@ -120,6 +113,30 @@ void MatrixWorkerTable<T>::Add(const std::vector<integer_t>& row_ids,
   }
   WorkerTable::Add(ids_blob, data_blob, option);
   Log::Debug("[Add] worker = %d, #rows_set = %d\n", MV_Rank(), row_ids.size());
+}
+
+template <typename T>
+void MatrixWorkerTable<T>::Add(T* data, size_t size, integer_t* row_ids,
+                               integer_t row_ids_size,
+                               const AddOption* option) {
+  if (row_ids_size == 0) {
+    CHECK(size == num_col_ * num_row_);
+    integer_t row_id = -1;
+    Blob ids_blob(&row_id, sizeof(integer_t));
+    Blob data_blob(data, size * sizeof(T));
+    WorkerTable::Add(ids_blob, data_blob, option);
+    Log::Debug("[Add] worker = %d, #row = %d\n", MV_Rank(), row_id);
+  } else {
+    CHECK(size == num_col_);
+    Blob ids_blob(row_ids, sizeof(integer_t) * row_ids_size);
+    Blob data_blob(row_ids_size * row_size_);
+    //copy each row
+    for (auto i = 0; i < row_ids_size; ++i){
+      memcpy(data_blob.data() + i * row_size_, &data[i * num_col_], row_size_);
+    }
+    WorkerTable::Add(ids_blob, data_blob, option);
+    Log::Debug("[Add] worker = %d, #rows_set = %d\n", MV_Rank(), row_ids_size);
+  }
 }
 
 template <typename T>

--- a/src/table/matrix_table.cpp
+++ b/src/table/matrix_table.cpp
@@ -129,11 +129,7 @@ void MatrixWorkerTable<T>::Add(T* data, size_t size, integer_t* row_ids,
   } else {
     CHECK(size == num_col_);
     Blob ids_blob(row_ids, sizeof(integer_t) * row_ids_size);
-    Blob data_blob(row_ids_size * row_size_);
-    //copy each row
-    for (auto i = 0; i < row_ids_size; ++i){
-      memcpy(data_blob.data() + i * row_size_, &data[i * num_col_], row_size_);
-    }
+    Blob data_blob(data, row_ids_size * row_size_);
     WorkerTable::Add(ids_blob, data_blob, option);
     Log::Debug("[Add] worker = %d, #rows_set = %d\n", MV_Rank(), row_ids_size);
   }

--- a/src/table/matrix_table.cpp
+++ b/src/table/matrix_table.cpp
@@ -116,9 +116,8 @@ void MatrixWorkerTable<T>::Add(const std::vector<integer_t>& row_ids,
 }
 
 template <typename T>
-void MatrixWorkerTable<T>::Add(T* data, size_t size, integer_t* row_ids,
-                               integer_t row_ids_size,
-                               const AddOption* option) {
+void MatrixWorkerTable<T>::Add(T* data, size_t size, const AddOption* option,
+                               integer_t* row_ids, integer_t row_ids_size) {
   if (row_ids_size == 0) {
     CHECK(size == num_col_ * num_row_);
     integer_t row_id = -1;


### PR DESCRIPTION
- Remove previous add whole tale interface (cause it's conflict with unified interface).
- Add unified interface for matrix table add.
  - You can add whole table by only passing `data` and `size`, same as removed previous implementation.
  - When the `row_ids` and `row_id_size` is not `null`, it can perform partial add.
  - The `data` is always `T*` for simplicity, there is not need to make an array of array.

P.S. This interface is used for better binding implementation.