### PR TITLE
Update lua/python binding according to new matrix table get interface.

### DIFF
--- a/binding/lua/multiverso.lua
+++ b/binding/lua/multiverso.lua
@@ -85,7 +85,7 @@ function mv.ArrayTableHandler:get()
 end
 
 function mv.ArrayTableHandler:add(data)
-    cdata = util.array2cdata(data, tonumber(self._size))
+    cdata = util.tensor2cdata(data)
     libmv.MV_AddArrayTable(self._handler[0], cdata, self._size)
 end
 
@@ -116,7 +116,7 @@ function mv.MatrixTableHandler:get(row_ids)
         data = util.cdata2array(cdata, tonumber(self._size))
         return torch.reshape(data, tonumber(self._num_row), tonumber(self._num_col))
     else
-        crow_ids = util.array2cdata(row_ids, #row_ids, "int[?]")
+        crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
         cdata = ffi.new("float*[?]", #row_ids * self._num_col)
         lib.MV_GetMatrixTableByRows(self._handler[0], crow_ids, crow_ids_n, self._num_col, cdata)
@@ -127,13 +127,13 @@ end
 
 function mv.MatrixTableHandler:add(data, row_ids)
     if row_ids == nil then
-        cdata = util.array2cdata(data, tonumber(self._size))
+        cdata = util.tensor2cdata(data)
         libmv.MV_AddMatrixTableAll(self._handler[0], cdata, self._size)
     else
         data = torch.reshape(data, #row_ids, tonumber(self._num_col))
-        crow_ids = util.array2cdata(row_ids, #row_ids, "int[?]")
+        crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
-        cdata = util.matrix2cdata(data, #row_ids, tonumber(self._num_col))
+        cdata = util.tensor2cdata(data)
         libmv.MV_AddMatrixTableByRows(self._handler[0], cdata, self._num_col,
                                       crow_ids, crow_ids_n)
     end

--- a/binding/lua/multiverso.lua
+++ b/binding/lua/multiverso.lua
@@ -23,8 +23,8 @@ ffi.cdef[[
     void MV_NewMatrixTable(int num_row, int num_col, TableHandler* out);
     void MV_GetMatrixTableAll(TableHandler handler, float* data, int size);
     void MV_AddMatrixTableAll(TableHandler handler, float* data, int size);
-    void MV_GetMatrixTableByRows(TableHandler handler, float* data, int num_col, int row_ids[], int row_ids_n);
-    void MV_AddMatrixTableByRows(TableHandler handler, float* data, int num_col, int row_ids[], int row_ids_n);
+    void MV_GetMatrixTableByRows(TableHandler handler, float* data, int size, int row_ids[], int row_ids_n);
+    void MV_AddMatrixTableByRows(TableHandler handler, float* data, int size, int row_ids[], int row_ids_n);
 ]]
 
 package.cpath = "../../build/src/?.so;" .. package.cpath
@@ -119,7 +119,8 @@ function mv.MatrixTableHandler:get(row_ids)
         crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
         cdata = ffi.new("float[?]", #row_ids * self._num_col)
-        libmv.MV_GetMatrixTableByRows(self._handler[0], cdata, self._num_col,
+        libmv.MV_GetMatrixTableByRows(self._handler[0], cdata,
+                                      crow_ids_n * self._num_col,
                                       crow_ids, crow_ids_n)
         data = util.cdata2tensor(cdata, tonumber(#row_ids * self._num_col))
         return torch.reshape(data, #row_ids, tonumber(self._num_col))
@@ -135,7 +136,8 @@ function mv.MatrixTableHandler:add(data, row_ids)
         crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
         cdata = util.tensor2cdata(data)
-        libmv.MV_AddMatrixTableByRows(self._handler[0], cdata, self._num_col,
+        libmv.MV_AddMatrixTableByRows(self._handler[0], cdata,
+                                      crow_ids_n * self._num_col,
                                       crow_ids, crow_ids_n)
     end
 end

--- a/binding/lua/multiverso.lua
+++ b/binding/lua/multiverso.lua
@@ -81,7 +81,7 @@ end
 function mv.ArrayTableHandler:get()
     cdata = ffi.new("float[?]", self._size)
     libmv.MV_GetArrayTable(self._handler[0], cdata, self._size)
-    return util.cdata2array(cdata, tonumber(self._size))
+    return util.cdata2tensor(cdata, tonumber(self._size))
 end
 
 function mv.ArrayTableHandler:add(data)
@@ -113,14 +113,14 @@ function mv.MatrixTableHandler:get(row_ids)
     if row_ids == nil then
         cdata = ffi.new("float[?]", self._size)
         libmv.MV_GetMatrixTableAll(self._handler[0], cdata, self._size)
-        data = util.cdata2array(cdata, tonumber(self._size))
+        data = util.cdata2tensor(cdata, tonumber(self._size))
         return torch.reshape(data, tonumber(self._num_row), tonumber(self._num_col))
     else
         crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
         cdata = ffi.new("float*[?]", #row_ids * self._num_col)
         lib.MV_GetMatrixTableByRows(self._handler[0], crow_ids, crow_ids_n, self._num_col, cdata)
-        data = util.cdata2array(cdata, tonumber(self._size))
+        data = util.cdata2tensor(cdata, tonumber(self._size))
         return torch.reshape(data, #row_ids, self._num_col)
     end
 end

--- a/binding/lua/multiverso.lua
+++ b/binding/lua/multiverso.lua
@@ -23,7 +23,7 @@ ffi.cdef[[
     void MV_NewMatrixTable(int num_row, int num_col, TableHandler* out);
     void MV_GetMatrixTableAll(TableHandler handler, float* data, int size);
     void MV_AddMatrixTableAll(TableHandler handler, float* data, int size);
-    void MV_GetMatrixTableByRows(TableHandler handler, int row_ids[], int row_ids_n, int num_col,  float** data);
+    void MV_GetMatrixTableByRows(TableHandler handler, float* data, int num_col, int row_ids[], int row_ids_n);
     void MV_AddMatrixTableByRows(TableHandler handler, float* data, int num_col, int row_ids[], int row_ids_n);
 ]]
 
@@ -118,10 +118,11 @@ function mv.MatrixTableHandler:get(row_ids)
     else
         crow_ids = util.tensor2cdata(row_ids, 'int')
         crow_ids_n = ffi.new("int", #row_ids)
-        cdata = ffi.new("float*[?]", #row_ids * self._num_col)
-        lib.MV_GetMatrixTableByRows(self._handler[0], crow_ids, crow_ids_n, self._num_col, cdata)
-        data = util.cdata2tensor(cdata, tonumber(self._size))
-        return torch.reshape(data, #row_ids, self._num_col)
+        cdata = ffi.new("float[?]", #row_ids * self._num_col)
+        libmv.MV_GetMatrixTableByRows(self._handler[0], cdata, self._num_col,
+                                      crow_ids, crow_ids_n)
+        data = util.cdata2tensor(cdata, tonumber(#row_ids * self._num_col))
+        return torch.reshape(data, #row_ids, tonumber(self._num_col))
     end
 end
 

--- a/binding/lua/test.lua
+++ b/binding/lua/test.lua
@@ -48,12 +48,20 @@ function mv_test.testMatrix()
         mv.barrier()
         data = tbh:get()
         mv.barrier()
-        for j = 1, data:size()[1] do
-            for k = 1, data:size()[2] do
+        for j = 1, data:size(1) do
+            for k = 1, data:size(2) do
                 expected = ((j - 1) * num_col + k) * i * num_workers
                 if row_ids_set[j - 1] then
                     expected = expected + ((j - 1) * num_col + k) * i * num_workers
                 end
+                mv_tester:eq(expected, data[j][k])
+            end
+        end
+        data = tbh:get(row_ids)
+        mv.barrier()
+        for j = 1, data:size(1) do
+            for k = 1, data:size(2) do
+                expected = (row_ids[j] * num_col + k) * i * num_workers * 2
                 mv_tester:eq(expected, data[j][k])
             end
         end

--- a/binding/lua/util.lua
+++ b/binding/lua/util.lua
@@ -4,21 +4,28 @@ util = {}
 
 ffi = require('ffi')
 
+util.tensor_type = {
+    ['unsigned char'] = 'torch.ByteTensor',
+    ['char'] = 'torch.CharTensor',
+    ['short'] = 'torch.ShortTensor',
+    ['int'] = 'torch.IntTensor',
+    ['long'] = 'torch.LongTensor',
+    ['float'] ='torch.FloatTensor',
+    ['double'] = 'torch.DoubleTensor'
+}
+
+function util.tensor2cdata(data, data_type)
+    data_type = data_type or 'float'
+    tensor_type = util.tensor_type[data_type]
+    return torch.Tensor(data):contiguous():type(tensor_type):data()
+end
+
 function util.cdata2array(cdata, size)
     data = torch.Tensor(size)
     for i=1, size do
         data[i] = cdata[i - 1]
     end
     return data
-end
-
-function util.array2cdata(data, size, cdata_type)
-    cdata_type = cdata_type or "float[?]"
-    cdata = ffi.new(cdata_type, size)
-    for i=1, size do
-        cdata[i - 1] = data[i]
-    end
-    return cdata
 end
 
 function util.cdata2matrix(data, num_row, num_col)
@@ -29,18 +36,6 @@ function util.cdata2matrix(data, num_row, num_col)
         end
     end
     return data
-end
-
-function util.matrix2cdata(data, num_row, num_col, cdata_type)
-    cdata_type = cdata_type or "float*[?]"
-    cdata = ffi.new(cdata_type, num_row)
-    for i=1, num_row do
-        cdata[i - 1] = ffi.new("float[?]", num_col)
-        for j=1, num_col do
-            cdata[i - 1][j - 1] = data[i][j]
-        end
-    end
-    return cdata
 end
 
 function util.Set(list)

--- a/binding/lua/util.lua
+++ b/binding/lua/util.lua
@@ -20,21 +20,11 @@ function util.tensor2cdata(data, data_type)
     return torch.Tensor(data):contiguous():type(tensor_type):data()
 end
 
-function util.cdata2array(cdata, size)
-    data = torch.Tensor(size)
-    for i=1, size do
-        data[i] = cdata[i - 1]
-    end
-    return data
-end
-
-function util.cdata2matrix(data, num_row, num_col)
-    data = torch.Tensor(num_row, num_col)
-    for i=1, num_row do
-        for j=1, num_col do
-            data[i][j] = cdata[i - 1][j - 1]
-        end
-    end
+function util.cdata2tensor(cdata, sizes, data_type)
+    data_type = data_type or 'float'
+    tensor_type = util.tensor_type[data_type]
+    data = torch.Tensor(sizes):type(tensor_type)
+    ffi.copy(data:data(), cdata, data:nElement() * ffi.sizeof(data_type))
     return data
 end
 

--- a/binding/python/multiverso/api.py
+++ b/binding/python/multiverso/api.py
@@ -99,14 +99,11 @@ class MatrixTableHandler(TableHandler):
         else:
             row_ids_n = len(row_ids)
             int_array_type = c_int * row_ids_n
-            float_array_array_type = c_float * self._num_col * row_ids_n
-            float_pointer_array_type = POINTER(c_float) * row_ids_n
-
-            array_data = float_array_array_type()
-            c_data = float_pointer_array_type(*[row for row in array_data])
-            mv_lib.MV_GetMatrixTableByRows(self._handler, int_array_type(*row_ids),
-                row_ids_n, self._num_col, c_data)
-            return np.array(self._construct_matrix(array_data)).reshape((row_ids_n, self._num_col))
+            float_array_type = c_float * (row_ids_n * self._num_col)
+            c_data = float_array_type()
+            mv_lib.MV_GetMatrixTableByRows(self._handler, c_data, self._num_col,
+                                           int_array_type(*row_ids), row_ids_n)
+            return np.array(self._construct_matrix(c_data)).reshape((row_ids_n, self._num_col))
 
     def add(self, data=None, row_ids=None):
         '''

--- a/binding/python/multiverso/api.py
+++ b/binding/python/multiverso/api.py
@@ -101,7 +101,8 @@ class MatrixTableHandler(TableHandler):
             int_array_type = c_int * row_ids_n
             float_array_type = c_float * (row_ids_n * self._num_col)
             c_data = float_array_type()
-            mv_lib.MV_GetMatrixTableByRows(self._handler, c_data, self._num_col,
+            mv_lib.MV_GetMatrixTableByRows(self._handler, c_data,
+                                           row_ids_n * self._num_col,
                                            int_array_type(*row_ids), row_ids_n)
             return np.array(self._construct_matrix(c_data)).reshape((row_ids_n, self._num_col))
 
@@ -124,5 +125,6 @@ class MatrixTableHandler(TableHandler):
             float_array_type = c_float * (self._num_col * row_ids_n)
 
             c_data = float_array_type(* np.array(data).reshape((-1, )))
-            mv_lib.MV_AddMatrixTableByRows(self._handler, c_data, self._num_col,
-                int_array_type(*row_ids), row_ids_n)
+            mv_lib.MV_AddMatrixTableByRows(self._handler, c_data,
+                                           row_ids_n * self._num_col,
+                                           int_array_type(*row_ids), row_ids_n)

--- a/binding/python/multiverso/test.py
+++ b/binding/python/multiverso/test.py
@@ -22,6 +22,7 @@ def TestMatrix():
     num_row = 11
     num_col = 10
     size = num_col * num_row
+    workers_num = mv.workers_num()
     tbh = mv.MatrixTableHandler(num_row, num_col)
     mv.barrier()
     for count in xrange(1, 20):
@@ -33,9 +34,15 @@ def TestMatrix():
         mv.barrier()
         for i, row in enumerate(data):
             for j, actual in enumerate(row):
-                expected = (i * num_col + j) * count * mv.workers_num()
+                expected = (i * num_col + j) * count * workers_num
                 if i in row_ids:
-                    expected += (i * num_col + j) * count * mv.workers_num()
+                    expected += (i * num_col + j) * count * workers_num
+                assert(expected == actual)
+        data = tbh.get(row_ids)
+        mv.barrier()
+        for i, row in enumerate(data):
+            for j, actual in enumerate(row):
+                expected = (row_ids[i] * num_col + j) * count * workers_num * 2
                 assert(expected == actual)
     mv.shutdown()
 

--- a/include/multiverso/c_api.h
+++ b/include/multiverso/c_api.h
@@ -40,8 +40,9 @@ DllExport void MV_GetMatrixTableAll(TableHandler handler, float* data, int size)
 
 DllExport void MV_AddMatrixTableAll(TableHandler handler, float* data, int size);
 
-DllExport void MV_GetMatrixTableByRows(TableHandler handler, int row_ids[],
-                                        int row_ids_n, int num_col, float* data[]);
+DllExport void MV_GetMatrixTableByRows(TableHandler handler, float* data,
+                                       int num_col, int row_ids[],
+                                       int row_ids_n);
 
 DllExport void MV_AddMatrixTableByRows(TableHandler handler, float* data,
                                        int num_col, int row_ids[],

--- a/include/multiverso/c_api.h
+++ b/include/multiverso/c_api.h
@@ -41,12 +41,10 @@ DllExport void MV_GetMatrixTableAll(TableHandler handler, float* data, int size)
 DllExport void MV_AddMatrixTableAll(TableHandler handler, float* data, int size);
 
 DllExport void MV_GetMatrixTableByRows(TableHandler handler, float* data,
-                                       int num_col, int row_ids[],
-                                       int row_ids_n);
+                                       int size, int row_ids[], int row_ids_n);
 
 DllExport void MV_AddMatrixTableByRows(TableHandler handler, float* data,
-                                       int num_col, int row_ids[],
-                                       int row_ids_n);
+                                       int size, int row_ids[], int row_ids_n);
 
 // typedef void* ArrayWorkerFloat;
 // typedef void* ArrayServerFloat;

--- a/include/multiverso/table/matrix_table.h
+++ b/include/multiverso/table/matrix_table.h
@@ -29,6 +29,9 @@ public:
   void Get(const std::vector<integer_t>& row_ids,
            const std::vector<T*>& data_vec, size_t size);
 
+  // Get specific rows.
+  void Get(T* data, size_t size, integer_t* row_ids, integer_t row_ids_size);
+
   // Add whole table
   void Add(T* data, size_t size, const AddOption* option = nullptr);
 
@@ -39,6 +42,7 @@ public:
            const std::vector<T*>& data_vec, size_t size, 
            const AddOption* option = nullptr);
 
+  // Add specific rows.
   void Add(T* data, size_t size, integer_t* row_ids, integer_t row_ids_size,
            const AddOption* option = nullptr);
 

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -69,11 +69,10 @@ void MV_AddMatrixTableAll(TableHandler handler, float* data, int size) {
   worker->Add(data, size);
 }
 
-void MV_GetMatrixTableByRows(TableHandler handler, int row_ids[],
-                              int row_ids_n, int num_col,  float** data) {
+void MV_GetMatrixTableByRows(TableHandler handler, float* data, int num_col,
+                             int row_ids[], int row_ids_n) {
   auto worker = reinterpret_cast<multiverso::MatrixWorkerTable<float>*>(handler);
-  worker->Get(std::vector<multiverso::integer_t>(row_ids, row_ids + row_ids_n),
-              std::vector<float*>(data, data + row_ids_n), num_col);
+  worker->Get(data, num_col, row_ids, row_ids_n);
 }
 
 void MV_AddMatrixTableByRows(TableHandler handler, float* data, int num_col,

--- a/src/c_api.cpp
+++ b/src/c_api.cpp
@@ -69,16 +69,16 @@ void MV_AddMatrixTableAll(TableHandler handler, float* data, int size) {
   worker->Add(data, size);
 }
 
-void MV_GetMatrixTableByRows(TableHandler handler, float* data, int num_col,
+void MV_GetMatrixTableByRows(TableHandler handler, float* data, int size,
                              int row_ids[], int row_ids_n) {
   auto worker = reinterpret_cast<multiverso::MatrixWorkerTable<float>*>(handler);
-  worker->Get(data, num_col, row_ids, row_ids_n);
+  worker->Get(data, size, row_ids, row_ids_n);
 }
 
-void MV_AddMatrixTableByRows(TableHandler handler, float* data, int num_col,
+void MV_AddMatrixTableByRows(TableHandler handler, float* data, int size,
                              int row_ids[], int row_ids_n) {
   auto worker = reinterpret_cast<multiverso::MatrixWorkerTable<float>*>(handler);
-  worker->Add(data, num_col, row_ids, row_ids_n);
+  worker->Add(data, size, row_ids, row_ids_n);
 }
 
   //ArrayServerFloat newArrayServerFloat(int i) {

--- a/src/table/matrix_table.cpp
+++ b/src/table/matrix_table.cpp
@@ -90,6 +90,19 @@ void MatrixWorkerTable<T>::Get(const std::vector<integer_t>& row_ids,
 }
 
 template <typename T>
+void MatrixWorkerTable<T>::Get(T* data, size_t size, integer_t* row_ids,
+                               integer_t row_ids_size) {
+  CHECK(size == num_col_ * row_ids_size);
+  for (auto i = 0; i < num_row_ + 1; ++i) row_index_[i] = nullptr;
+  for (auto i = 0; i < row_ids_size; ++i){
+    row_index_[row_ids[i]] = &data[i * num_col_];
+  }
+  Blob ids_blob(row_ids, sizeof(integer_t) * row_ids_size);
+  WorkerTable::Get(ids_blob);
+  Log::Debug("[Get] worker = %d, #rows_set = %d\n", MV_Rank(), row_ids_size);
+}
+
+template <typename T>
 void MatrixWorkerTable<T>::Add(T* data, size_t size, const AddOption* option) {
   CHECK(size == num_col_ * num_row_);
   integer_t whole_table = -1;
@@ -126,7 +139,7 @@ template <typename T>
 void MatrixWorkerTable<T>::Add(T* data, size_t size, integer_t* row_ids,
                                integer_t row_ids_size,
                                const AddOption* option) {
-  CHECK(size == num_col_);
+  CHECK(size == num_col_ * row_ids_size);
   Blob ids_blob(row_ids, sizeof(integer_t) * row_ids_size);
   Blob data_blob(data, row_ids_size * row_size_);
   WorkerTable::Add(ids_blob, data_blob, option);


### PR DESCRIPTION
- Use new matrix get interface in `c_api`.
- [lua/python binding] Update lua/python binding according to `c_api` change.
- [lua/python binding] Add unittest for new matrix table get interface.
- [lua binding] Better conversion between `ffi.cdata` and `torch.Tensor`.
- Minor changes.

P.S. Based on #62 