### PR TITLE
Add multiverso version fb.resnet.torch as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "binding/lua/demos/fb.resnet.torch"]
+	path = binding/lua/demos/fb.resnet.torch
+	url = https://github.com/huxuan/fb.resnet.torch.git
+	branch = multiverso

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "binding/lua/demos/fb.resnet.torch"]
 	path = binding/lua/demos/fb.resnet.torch
-	url = https://github.com/huxuan/fb.resnet.torch.git
+	url = https://github.com/Microsoft/fb.resnet.torch.git
 	branch = multiverso


### PR DESCRIPTION
This is to add a multiverso version `fb.resnet.torch`. Actually I am not sure whether we should make this as a submodule. A submodule will make it easy to update the code base when the upstream has new commits. But users will need extra effort to get the code base. And it's a little strange to have a submodule from my account. Maybe we should use Microsoft account to fork original `fb.resnet.torch`?

@chivee @feiga @you-n-g , any suggestions?