### PR TITLE
Update the build instruction in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,14 @@ Build
 
 **Linux** (Tested on Ubuntu 14.04)
 
-1. Run `sudo apt-get install libopenmpi-dev openmpi-bin build-essential cmake`
-2. Run `mkdir build`
-3. Run `cd build`
-4. Run `cmake ..`
-5. Run `make && make install`
+```
+sudo apt-get install libopenmpi-dev openmpi-bin build-essential cmake
+mkdir build
+cd build
+cmake ..
+make
+sudo make install
+```
 
 **Windows**
 


### PR DESCRIPTION
Two motivations:

1. Clean the style, use code block instead of inline code style so that user can simply copy all commands and run them by only one paste.
2. Add `sudo` for `make install`.