### PR TITLE
add post-install ldconfig command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,4 +34,4 @@ configure_file(
     IMMEDIATE @ONLY)
 
 add_custom_target(uninstall
-    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)# 
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,3 +8,6 @@ add_library(multiverso SHARED ${MULTIVERSO_SRC})
 target_link_libraries(multiverso ${MPI_LIBRARY})
 
 install (TARGETS multiverso DESTINATION lib)
+if (UNIX)
+    install(CODE "execute_process(COMMAND ldconfig)")  # run ldconfig. Otherwise ld.so.cache won't be created.
+endif()


### PR DESCRIPTION
This solution is not so elegant. I think the ldconfig command should put in `CMakeList.txt` instead of `src/CMakeLists.txt`. 

However I encountered some problem about the running order of the command. 
After discussion in the community, Here is another solution http://public.kitware.com/pipermail/cmake/2016-June/063723.html

But I think current solution in this commit will be enough in our case.