### PR TITLE
install all headers to system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,7 @@ ADD_SUBDIRECTORY(Test)
 ADD_SUBDIRECTORY(Applications/WordEmbedding)
 ADD_SUBDIRECTORY(Applications/LogisticRegression)
 
-# TODO: more header files should be installed. Only c_api.h is installed so far
-install (FILES ${PROJECT_SOURCE_DIR}/include/multiverso/c_api.h DESTINATION include/multiverso)
+install (DIRECTORY ${PROJECT_SOURCE_DIR}/include/multiverso DESTINATION include)
 
 
 # uninstall target


### PR DESCRIPTION
@huihuiw   This path will enable  `make install` installing all header files into system path.
Then you can use multiverso headers without  setting environment path to multiverso header files.