### PR TITLE
link LogisticRegression with pthread

### DIFF
--- a/Applications/LogisticRegression/CMakeLists.txt
+++ b/Applications/LogisticRegression/CMakeLists.txt
@@ -34,4 +34,4 @@ set(SRC ${SRC_MODEL} ${SRC_OBJECTIVE} ${SRC_REGULAR} ${SRC_UPDATER} ${SRC_UTIL} 
 
 add_executable(LogisticRegression ${SRC})
 
-target_link_libraries(LogisticRegression multiverso ${MPI_CXX_LIBRARIES})
+target_link_libraries(LogisticRegression multiverso ${MPI_CXX_LIBRARIES} pthread)


### PR DESCRIPTION
This fixed my compiling problem with gcc 5.4.0 on Ubuntu 16.04.1. 
I hope it does not hurt your build system.

Best regards