### PR TITLE
Fix typos in comments, log messages and other strings

### DIFF
--- a/Applications/LogisticRegression/src/configure.h
+++ b/Applications/LogisticRegression/src/configure.h
@@ -51,8 +51,8 @@ public:
 
   // when provided, will load model data when LogReg init
   std::string init_model_file = "";
-  // input data for trainning
-  // use ; to seperate different files
+  // input data for training
+  // use ; to separate different files
   std::string train_file = "train.data";
   // default / weight / ftrl
   // [default]
@@ -62,7 +62,7 @@ public:
   //    2. dense data use format as
   //      label value value ...
   // [weight]
-  //  the first colum is label:weight(double)
+  //  the first column is label:weight(double)
   //  others the same to default
   // [bsparse]
   //  for sparse data, read binary file, each sample as:

--- a/Applications/LogisticRegression/src/model/model.h
+++ b/Applications/LogisticRegression/src/model/model.h
@@ -48,7 +48,7 @@ public:
   static Model<EleType>* Get(Configure& config);
 
 protected:
-  // copmpute update delta
+  // compute update delta
   virtual float GetGradient(Sample<EleType>* sample, DataBlock<EleType>* delta);
   // update table
   virtual void UpdateTable(DataBlock<EleType>* delta);

--- a/Applications/LogisticRegression/src/reader.h
+++ b/Applications/LogisticRegression/src/reader.h
@@ -15,7 +15,7 @@
 
 namespace logreg {
 
-// a async reader for reading matrix data
+// an async reader for reading matrix data
 // each line as a row
 template<typename EleType>
 class SampleReader {

--- a/Applications/LogisticRegression/src/util/hopscotch_hash.h
+++ b/Applications/LogisticRegression/src/util/hopscotch_hash.h
@@ -289,7 +289,7 @@ void Hopscotch<EleType>::Insert(Bucket* home, size_t key, EleType *val) {
     ++move;
   }
 
-  // outside neighbour
+  // outside neighbor
   if ((move - home) >= neighbour_size_) {
     // try displace
     move = Displace(home, move);

--- a/Applications/WordEmbedding/src/block_queue.h
+++ b/Applications/WordEmbedding/src/block_queue.h
@@ -11,7 +11,7 @@ namespace wordembedding {
 
   /*!
   * \brief The block queue push and pop the block data. Load data thread push 
-  * datablock in it and traning thread take datablock from it.
+  * datablock in it and training thread take datablock from it.
   */
   class BlockQueue {
   public:

--- a/Applications/WordEmbedding/src/communicator.cpp
+++ b/Applications/WordEmbedding/src/communicator.cpp
@@ -50,7 +50,7 @@ namespace wordembedding {
   inline void Communicator::AddRows(multiverso::MatrixWorkerTable<real>* table,
     std::vector<int> &row_ids, std::vector<real *> &ptrs, int size) {
 	if (row_ids.size() ==0){
-		multiverso::Log::Debug("Warnning: add rows size is zeor in AddRows function.");
+		multiverso::Log::Debug("Warning: add rows size is zeor in AddRows function.");
 		return;
 	}
 	multiverso::AddOption add_option;
@@ -60,7 +60,7 @@ namespace wordembedding {
   void Communicator::GetWorkerTableRows(std::vector<int> &row_nums,
     std::vector<real*> &blocks, int embeding_size) {
 	if (row_nums.size() == 0) {
-		multiverso::Log::Debug("Warnning: add rows size is zeor in GetWorkerTableRows function.");
+		multiverso::Log::Debug("Warning: add rows size is zeor in GetWorkerTableRows function.");
 		return;
 	}
 	worker_input_table_->Get(row_nums, blocks, embeding_size);
@@ -69,7 +69,7 @@ namespace wordembedding {
   inline void Communicator::GetRows(multiverso::MatrixWorkerTable<real>* table,
     std::vector<int> &row_ids, std::vector<real *> &ptrs, int size) {
 	if (row_ids.size() == 0) {
-		multiverso::Log::Debug("Warnning: add rows size is zeor in GetRows function.");
+		multiverso::Log::Debug("Warning: add rows size is zeor in GetRows function.");
 		return;
 	}
     table->Get(row_ids, ptrs, size);

--- a/Applications/WordEmbedding/src/dictionary.h
+++ b/Applications/WordEmbedding/src/dictionary.h
@@ -51,7 +51,7 @@ namespace wordembedding {
     /*!
     * \brief Insert word-freq pair to the dictionary
     * \param word the word string
-    * \param cnt  the word's freqency
+    * \param cnt the word's frequency
     */
     void Insert(const char* word, int64 cnt = 1);
     /*!

--- a/Applications/WordEmbedding/src/distributed_wordembedding.cpp
+++ b/Applications/WordEmbedding/src/distributed_wordembedding.cpp
@@ -180,7 +180,7 @@ namespace wordembedding {
       for (int64 cur = 0; cur < file_size; cur += option_->data_block_size) {
         clock_t start_block = clock();
 
-        //if don't use pipeline, traning after getting parameters. 
+        //if don't use pipeline, training after getting parameters. 
         if (option_->is_pipeline == false) {
           #pragma omp parallel for num_threads(option_->thread_cnt)
           for (int i = 0; i < option_->thread_cnt; ++i) {
@@ -237,7 +237,7 @@ namespace wordembedding {
       }
     }
 
-    multiverso::Log::Info("Rank %d Finish Traning %d Block.\n", process_id_,
+    multiverso::Log::Info("Rank %d Finish Training %d Block.\n", process_id_,
       data_block_count);
 
     StopCollectWordcountThread();

--- a/Applications/WordEmbedding/src/distributed_wordembedding.h
+++ b/Applications/WordEmbedding/src/distributed_wordembedding.h
@@ -2,7 +2,7 @@
 #define WORDEMBEDDING_DISTRIBUTED_WORDEMBEDDING_H_
 /*!
 * file distributed_wordembedding.h
-* \brief Class Distributed_wordembedding describles the main frame of 
+* \brief Class Distributed_wordembedding describes the main frame of 
 * WordEmbedding and some useful functions
 */
 

--- a/Applications/WordEmbedding/src/trainer.h
+++ b/Applications/WordEmbedding/src/trainer.h
@@ -2,7 +2,7 @@
 #define WORDEMBEDDING_TRAINER_H_
 /*!
 * file trainer.h
-* \brief Class Trainer trains the model by every trainiteration
+* \brief Class Trainer trains the model by every train iteration
 */
 
 #include <thread>

--- a/Applications/WordEmbedding/src/wordembedding.h
+++ b/Applications/WordEmbedding/src/wordembedding.h
@@ -36,8 +36,6 @@ namespace wordembedding {
     /*!
     * \brief PrepareParameter for parameterloader threat
     * \param data_block datablock for parameterloader to parse
-    * \param input_nodes  input_nodes represent the parameter which input_layer includes
-    * \param output_nodes output_nodes represent the parameter which output_layer inclueds
     */
     void PrepareData(DataBlock *data_block);
     /*!
@@ -45,7 +43,7 @@ namespace wordembedding {
     */
     void UpdateLearningRate();
     /*!
-    * \brief Set the input(output)-embeddding weight
+    * \brief Set the input(output)-embedding weight
     */
     void SetWeightIE(int input_node_id, real* ptr);
     void SetWeightEO(int output_node_id, real* ptr);
@@ -56,12 +54,12 @@ namespace wordembedding {
     real* GetWeightIE(int input_node_id);
     real* GetWeightEO(int output_node_id);
     /*!
-    * \brief Set the input(output) gradient-embeddding weight when using adagrad
+    * \brief Set the input(output) gradient-embedding weight when using adagrad
     */
     void SetSumGradient2IE(int input_node_id, real* ptr);
     void SetSumGradient2EO(int output_node_id, real* ptr);
     /*!
-    * \brief Return the input(output) gradient-embeddding weight when using adagrad
+    * \brief Return the input(output) gradient-embedding weight when using adagrad
     */
     real* GetSumGradient2IE(int input_node_id);
     real* GetSumGradient2EO(int output_node_id);
@@ -86,7 +84,7 @@ namespace wordembedding {
       std::vector<int>& input_nodes,
       std::vector<std::pair<int, int> >& output_nodes, std::vector <int> &negativesample_pools);
     /*!
-    * \brief Parse a sentence and deepen into two branchs
+    * \brief Parse a sentence and deepen into two branches
     * \one for TrainNN,the other one is for Parameter_parse&request
     */
     void ParseSentence(int* sentence, int sentence_length,
@@ -104,8 +102,8 @@ namespace wordembedding {
     * \param label record the label of every output-embedding vector
     * \param word_idx the index of the output-embedding vector
     * \param classifier store the output-embedding vector
-    * \param store the hidden layer vector
-    * \param store the hidden-error which is used
+    * \param hidden_act store the hidden layer vector
+    * \param hidden_err store the hidden-error which is used
     * \to update the input-embedding vector
     */
     void BPOutputLayer(int label, int word_idx, real* classifier,
@@ -113,9 +111,9 @@ namespace wordembedding {
 
     /*!
     * \brief Train a window sample and update the
-    * \input-embedding&output-embedding vectors
+    * \input-embedding & output-embedding vectors
     * \param input_nodes represent the input nodes
-    * \param output_nodes represent the ouput nodes
+    * \param output_nodes represent the output nodes
     * \param hidden_act  store the hidden layer vector
     * \param hidden_err  store the hidden layer error
     */

--- a/Test/test_matrix_perf.cpp
+++ b/Test/test_matrix_perf.cpp
@@ -171,4 +171,4 @@ void TestDensePerf(int argc, char* argv[]) {
 }
 
 }  // namespace test
-}  // namesapce multiverso
+}  // namespace multiverso

--- a/Test/unittests/test_multiverso.cpp
+++ b/Test/unittests/test_multiverso.cpp
@@ -1,5 +1,5 @@
 #ifndef _WIN32
-// Use dynamic library on linux
+// Use dynamic library on Linux
 #define BOOST_TEST_DYN_LINK
 #endif
 

--- a/binding/C#/MultiversoCLR/MultiversoCLR.cpp
+++ b/binding/C#/MultiversoCLR/MultiversoCLR.cpp
@@ -55,7 +55,7 @@ namespace MultiversoCLR {
   }
   void MultiversoWrapper::Shutdown() {
     // The false means finalize_net = false
-    // We finalize the net resource seperately by calling MultiversoWrapper.NetFinalize
+    // We finalize the net resource separately by calling MultiversoWrapper.NetFinalize
     multiverso::MV_ShutDown(false);
   }
 

--- a/include/multiverso/dashboard.h
+++ b/include/multiverso/dashboard.h
@@ -61,7 +61,7 @@ private:
 #define REGISTER_MONITOR(name)           \
   static Monitor g_##name##_monitor(#name);
 
-// Guard with MONITOR macro in the code to monitor it's excuation
+// Guard with MONITOR macro in the code to monitor it's execution
 // Usage:
 // MONITOR_BEGIN(your_code_short_description)
 // your code

--- a/include/multiverso/io/io.h
+++ b/include/multiverso/io/io.h
@@ -71,7 +71,7 @@ public:
 
   /*!
   * \brief read data from Stream
-  * \param buf pointer to a memory buffe;
+  * \param buf pointer to a memory buffer;
   * \param size the size of buf
   */
   virtual size_t Read(void *buf, size_t size) = 0;

--- a/include/multiverso/net.h
+++ b/include/multiverso/net.h
@@ -31,7 +31,7 @@ public:
   virtual int size() const = 0;
   virtual int rank() const = 0;
 
-  // \return 1. > 0 sended size 2. = 0 not sended 3. < 0 net error
+  // \return 1. > 0 sent size 2. = 0 not sent 3. < 0 net error
   virtual int Send(MessagePtr& msg) = 0;
 
   // \return 1. > 0 received size 2. = 0 not received 3. < 0 net error

--- a/include/multiverso/net/allreduce_engine.h
+++ b/include/multiverso/net/allreduce_engine.h
@@ -15,7 +15,7 @@ class BruckMap {
 public:
   /*! \brief The communication times for one all gather operation */
   int k;
-  /*! \brief in_ranks[i] means the incomming rank on i-th communication */
+  /*! \brief in_ranks[i] means the incoming rank on i-th communication */
   std::vector<int> in_ranks;
   /*! \brief out_ranks[i] means the out rank on i-th communication */
   std::vector<int> out_ranks;
@@ -32,7 +32,7 @@ public:
 
 /*!
 * \brief node type on recursive halving algorithm
-* When number of machines is not power of 2, need group maiches into power of 2 group.
+* When number of machines is not power of 2, need group matches into power of 2 group.
 * And we can let each group has at most 2 machines.
 * if the group only has 1 machine. this machine is the normal node
 * if the grou has 2 machines, this group will have two type of nodes, one is the leader.
@@ -47,7 +47,7 @@ enum RecursiveHalvingNodeType {
 /*! \brief Network structure for recursive halving algorithm */
 class RecursiveHalvingMap {
 public:
-  /*! \brief Communication times for one recursize halving algorithm  */
+  /*! \brief Communication times for one recursive halving algorithm  */
   int k;
   /*! \brief Node type */
   RecursiveHalvingNodeType type;

--- a/include/multiverso/table_interface.h
+++ b/include/multiverso/table_interface.h
@@ -64,7 +64,7 @@ public:
   virtual void Load(Stream* s) = 0;
 };
 
-// discribe the server parameter storage data structure and related method
+// describe the server parameter storage data structure and related method
 class ServerTable : public Serializable {
 public:
   ServerTable();

--- a/include/multiverso/updater/updater.h
+++ b/include/multiverso/updater/updater.h
@@ -9,7 +9,7 @@ namespace multiverso {
 
 struct AddOption {
 public:
-  // TODO(qiwye): make these default value more flexiable
+  // TODO(qiwye): make these default value more flexible
   AddOption(){
     data_[0].i = MV_WorkerId(); 
     data_[1].f = 0.0f;
@@ -71,7 +71,7 @@ private:
 
 struct GetOption {
 public:
-  // TODO(qiwye): to make these Option configuable 
+  // TODO(qiwye): to make these Option configurable 
   GetOption(){
     data_[0].i = MV_WorkerId();
   }

--- a/include/multiverso/util/async_buffer.h
+++ b/include/multiverso/util/async_buffer.h
@@ -18,7 +18,7 @@ public:
     : buffer_writer_{ fill_buffer_action } {
     CHECK_NOTNULL(buffer0);
     CHECK_NOTNULL(buffer1);
-    //[TODO(qiwye)] to make buffer number configuable.
+    //[TODO(qiwye)] to make buffer number configurable.
     buffers_.resize(2);
     buffers_[0] = buffer0;
     buffers_[1] = buffer1;

--- a/include/multiverso/util/log.h
+++ b/include/multiverso/util/log.h
@@ -94,7 +94,7 @@ private:
   std::string GetLevelStr(LogLevel level);
 
   std::FILE *file_;  // A file pointer to the log file.
-  LogLevel level_;   // Only the message not less than level_ will be outputed.
+  LogLevel level_;   // Only the message not less than level_ will be outputted.
   bool is_kill_fatal_;  // If kill the process when fatal error occurs.
 
   // No copying allowed
@@ -126,7 +126,7 @@ public:
   static void ResetLogLevel(LogLevel level);
   /*!
   * \brief Resets the option of whether kill the process when fatal
-  *        error occurs. By defualt the option is false.
+  *        error occurs. By default the option is false.
   */
   static void ResetKillFatal(bool is_kill_fatal);
 

--- a/include/multiverso/util/mt_queue.h
+++ b/include/multiverso/util/mt_queue.h
@@ -33,7 +33,7 @@ public:
    * \brief Pop an element from the queue, if the queue is empty, thread
    *        call pop would be blocked
    * \param result the returned result
-   * \return true when pop sucessfully; false when the queue is exited
+   * \return true when pop successfully; false when the queue is exited
    */
   bool Pop(T& result);
 
@@ -44,7 +44,7 @@ public:
    * \brief Get the front element from the queue, if the queue is empty,
    *        threat who call front would be blocked. Not move semantics.
    * \param result the returned result
-   * \return true when pop sucessfully; false when the queue is exited
+   * \return true when pop successfully; false when the queue is exited
    */
   bool Front(T& result);
 

--- a/src/net/allreduce_engine.cpp
+++ b/src/net/allreduce_engine.cpp
@@ -126,7 +126,7 @@ void AllreduceEngine::ReduceScatter(char* input, int input_size, int, int* block
       linkers_->SendTo(recursive_halving_map_.neighbor, input, input_size);
     }
     else if (recursive_halving_map_.type == RecursiveHalvingNodeType::GroupLeader) {
-      //recieve neighbor data first
+      //receive neighbor data first
       int need_recv_cnt = input_size;
       linkers_->RecvFrom(recursive_halving_map_.neighbor, output, need_recv_cnt);
       reducer(output, input, input_size);

--- a/src/net/allreduce_topo.cpp
+++ b/src/net/allreduce_topo.cpp
@@ -26,10 +26,10 @@ BruckMap BruckMap::Construct(int rank, int num_machines) {
   }
   BruckMap bruckMap(k);
   for (int j = 0; j < k; ++j) {
-    // set incoming rank at k-th commuication
+    // set incoming rank at k-th communication
     const int in_rank = (rank + distance[j]) % num_machines;
     bruckMap.in_ranks[j] = in_rank;
-    // set outgoing rank at k-th commuication
+    // set outgoing rank at k-th communication
     const int out_rank = (rank - distance[j] + num_machines) % num_machines;
     bruckMap.out_ranks[j] = out_rank;
   }
@@ -45,7 +45,7 @@ RecursiveHalvingMap::RecursiveHalvingMap(RecursiveHalvingNodeType _type, int n) 
   k = n;
   if (type != RecursiveHalvingNodeType::Other) {
     for (int i = 0; i < n; ++i) {
-      // defalut set as -1
+      // default set as -1
       ranks.push_back(-1);
       send_block_start.push_back(-1);
       send_block_len.push_back(-1);

--- a/src/table/matrix.cpp
+++ b/src/table/matrix.cpp
@@ -147,7 +147,7 @@ template <typename T>
 void MatrixWorker<T>::Add(T* data, size_t size, const AddOption* option) {
   CHECK(size == num_col_ * num_row_);
   if (is_sparse_ && true) {
-    // REVIEW[qiwye] does this pre-optimation bring too much overhead?
+    // REVIEW[qiwye] does this pre-optimization bring too much overhead?
     std::vector<integer_t> row_ids;
     for (auto i = 0; i < num_row_; i++) {
       auto zero_count = std::count(data + (i * num_col_), data + ((i + 1) * num_col_), (T)0);

--- a/src/util/log.cpp
+++ b/src/util/log.cpp
@@ -6,7 +6,7 @@
 #include <string>
 
 namespace multiverso {
-// Creates a Logger intance writing messages into STDOUT.
+// Creates a Logger instance writing messages into STDOUT.
 Logger::Logger(LogLevel level) {
   level_ = level;
   file_ = nullptr;
@@ -131,7 +131,7 @@ std::string Logger::GetLevelStr(LogLevel level) {
   default: return "UNKNOW";
   }
 }
-//-- End of Logger rountine ----------------------------------------------/
+//-- End of Logger routine ----------------------------------------------/
 
 Logger Log::logger_;    // global (in process) static Logger instance
 

--- a/src/zoo.cpp
+++ b/src/zoo.cpp
@@ -98,7 +98,7 @@ void Zoo::StartPS() {
     worker->Start();
   }
   Barrier();
-  Log::Info("Rank %d: Multiverso start sucessfully\n", rank());
+  Log::Info("Rank %d: Multiverso start successfully\n", rank());
 }
 
 void Zoo::StopPS() {


### PR DESCRIPTION
List of fixed words:

- training
- separate
- column
- compute
- neighbor
- training
- warning
- frequency
- embedding
- communication
- default
- instance
- optimization
- routine

Also, fix doxygen description in `PrepareData` function.