### PR TITLE
Soften requirement on Lasagne version

### DIFF
--- a/binding/python/setup.py
+++ b/binding/python/setup.py
@@ -21,7 +21,7 @@ setup(name='multiverso-python',
       # lasagne-0.2 which is not released yet. Please replace the dev version
       # with the stable release later.
       dependency_links = ['https://github.com/Lasagne/Lasagne/tarball/master#egg=lasagne-0.2.dev1'],
-      install_requires=["theano>=0.8.2", "lasagne==0.2.dev1"],
+      install_requires=["theano>=0.8.2", "lasagne>=0.2.dev1"],
       classifiers=[
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",


### PR DESCRIPTION
We may have a newer version installed (maybe a local checkout) that already
 satisfies the requirement.