### PR TITLE
Fix the typo USE_INSTALL_MULTIVERSO -> INSTALL_MULTIVERSO .

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,9 +30,9 @@ ADD_SUBDIRECTORY(Test/unittests)
 ADD_SUBDIRECTORY(Applications/WordEmbedding)
 ADD_SUBDIRECTORY(Applications/LogisticRegression)
 
-if(USE_INSTALL_MULTIVERSO)
+if(INSTALL_MULTIVERSO)
     install (DIRECTORY ${PROJECT_SOURCE_DIR}/include/multiverso DESTINATION include)
-endif(USE_INSTALL_MULTIVERSO)
+endif(INSTALL_MULTIVERSO)
 
 
 # uninstall target


### PR DESCRIPTION
Fix the typo USE_INSTALL_MULTIVERSO -> INSTALL_MULTIVERSO which leads to absense of "include" dir in the installation destination.