### PR TITLE
Install Test directory into destination.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ ADD_SUBDIRECTORY(Applications/LogisticRegression)
 
 if(INSTALL_MULTIVERSO)
     install (DIRECTORY ${PROJECT_SOURCE_DIR}/include/multiverso DESTINATION include)
+    install (DIRECTORY ${PROJECT_SOURCE_DIR}/Test DESTINATION Test)
 endif(INSTALL_MULTIVERSO)
 
 


### PR DESCRIPTION
Multiverso's `Test` directory is requried by `CNTK` at building in https://github.com/Microsoft/CNTK/blob/master/Makefile . When redisributing Multiverso as a reusable library, it is desirable to ship `Test` along with `include` and `lib`. This commit adds `Test` into installation destination.