### PR TITLE
add WITHOUT_LDCONFIG option to cmake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Build
 sudo apt-get install libopenmpi-dev openmpi-bin build-essential cmake git
 git clone https://github.com/Microsoft/multiverso.git --recursive && cd multiverso
 mkdir build && cd build
-cmake .. && make && sudo make install
+cmake .. && make && sudo make install  # use "cmake -DWITHOUT_LDCONFIG=TRUE .." if you do not have root access to /etc/ld.so.cache, and add your libmultiverso.so to LD_LIBRARY_PATH after "make install"
 ```
 
 **Windows**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,6 @@ else()
 endif()
 
 install (TARGETS multiverso DESTINATION lib)
-if (UNIX)
+if (NOT WITHOUT_LDCONFIG AND UNIX)
     install(CODE "execute_process(COMMAND ldconfig)")  # run ldconfig. Otherwise ld.so.cache won't be created.
 endif()


### PR DESCRIPTION
For users do not have root access to `/etc/ld.so.cache`, 
current install will lead to permission denied error.

Therefore, it is good to provide this option, and ask user to add `libmultiverso.so` to `LD_LIBRARY_PATH`.