### PR TITLE
modify third_party/install.sh

### DIFF
--- a/third_party/install.sh
+++ b/third_party/install.sh
@@ -2,20 +2,26 @@
 # install third party library: 1. ZeroMQ, 2. MPICH2
 
 THIRD_PARTY_DIR=$PWD
+mkdir $THIRD_PARTY_DIR/include
 echo $TARGET_DIR
 
-ZMQ_DIR=zeromq-4.1.3
+ZMQ_DIR=libzmq
 MPI_DIR=mpich-3.0.4
 # 1. Get ZeroMQ
-wget http://download.zeromq.org/zeromq-4.1.3.tar.gz
-tar -zxf zeromq-4.1.3.tar.gz
+# wget http://download.zeromq.org/zeromq-4.1.3.tar.gz
+# tar -zxf zeromq-4.1.3.tar.gz
+git clone https://github.com/zeromq/libzmq
+# ./autogen.sh && ./configure && make -j 4
+# make check && make install
 
 # Build ZeroMQ
 # Make sure that libtool, pkg-config, build-essential, autoconf and automake
 # are installed.
 cd $ZMQ_DIR
+./autogen.sh
 ./configure --prefix=$THIRD_PARTY_DIR --without-libsodium
 make -j4
+make check
 make install -j4
 cd ..
 rm -rf $ZMQ_DIR
@@ -37,3 +43,9 @@ cd ..
 rm -rf $MPI_DIR
 
 rm *.tar.gz*
+
+# add lib to ~/.bashrc
+echo "LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:${THIRD_PARTY_DIR}/lib" >> ~/.bashrc
+source ~/.bashrc
+
+


### PR DESCRIPTION
Those who want to build LightLDA based on branch multiverso-initial, may find there are some errors when
run "multiverso/third_party/install.sh".  I have changed the install.sh(the way to build zeromq, move *.h file to include/,   add lib/ to LD_LIBRARY_PATH). This will help us install third_party libs with simply running install.sh.